### PR TITLE
Accessibility: restore button focus outline

### DIFF
--- a/ensureAsync.js
+++ b/ensureAsync.js
@@ -1,0 +1,67 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+exports.default = ensureAsync;
+
+var _setImmediate = require('./internal/setImmediate.js');
+
+var _setImmediate2 = _interopRequireDefault(_setImmediate);
+
+var _wrapAsync = require('./internal/wrapAsync.js');
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+/**
+ * Wrap an async function and ensure it calls its callback on a later tick of
+ * the event loop.  If the function already calls its callback on a next tick,
+ * no extra deferral is added. This is useful for preventing stack overflows
+ * (`RangeError: Maximum call stack size exceeded`) and generally keeping
+ * [Zalgo](http://blog.izs.me/post/59142742143/designing-apis-for-asynchrony)
+ * contained. ES2017 `async` functions are returned as-is -- they are immune
+ * to Zalgo's corrupting influences, as they always resolve on a later tick.
+ *
+ * @name ensureAsync
+ * @static
+ * @memberOf module:Utils
+ * @method
+ * @category Util
+ * @param {AsyncFunction} fn - an async function, one that expects a node-style
+ * callback as its last argument.
+ * @returns {AsyncFunction} Returns a wrapped function with the exact same call
+ * signature as the function passed in.
+ * @example
+ *
+ * function sometimesAsync(arg, callback) {
+ *     if (cache[arg]) {
+ *         return callback(null, cache[arg]); // this would be synchronous!!
+ *     } else {
+ *         doSomeIO(arg, callback); // this IO would be asynchronous
+ *     }
+ * }
+ *
+ * // this has a risk of stack overflows if many results are cached in a row
+ * async.mapSeries(args, sometimesAsync, done);
+ *
+ * // this will defer sometimesAsync's callback if necessary,
+ * // preventing stack overflows
+ * async.mapSeries(args, async.ensureAsync(sometimesAsync), done);
+ */
+function ensureAsync(fn) {
+    if ((0, _wrapAsync.isAsync)(fn)) return fn;
+    return function (...args /*, callback*/) {
+        var callback = args.pop();
+        var sync = true;
+        args.push((...innerArgs) => {
+            if (sync) {
+                (0, _setImmediate2.default)(() => callback(...innerArgs));
+            } else {
+                callback(...innerArgs);
+            }
+        });
+        fn.apply(this, args);
+        sync = false;
+    };
+}
+module.exports = exports['default'];


### PR DESCRIPTION
Restore high-contrast focus outline for primary and secondary buttons to improve keyboard navigation and visibility for users with low vision. This change reintroduces a 3px solid var(--focus-color) outline on :focus and sets outline-offset and border-radius to match button styles.